### PR TITLE
Simplify Select::run()

### DIFF
--- a/php/Job/Space/Select.php
+++ b/php/Job/Space/Select.php
@@ -45,14 +45,10 @@ class Select extends Job
 
             foreach ($data as $x => $tuple) {
                 foreach ($tuple as $y => $value) {
-                    if (is_object($value) && get_class($value) == Decimal::class) {
+                    if ($value instanceof Decimal) {
                         $value = $value->toString();
-                    }
-                    if (is_subclass_of($value, Uuid::class)) {
+                    } else if ($value instanceof Uuid)) {
                         $value = $value->toRfc4122();
-                    }
-                    if (is_numeric($value) && $value > 2 ^ 32 - 1) {
-                        $value = (string) $value;
                     }
                     $data[$x][$y] = $value;
                 }


### PR DESCRIPTION
`is_object()`, `get_class()` and `is_subclass_of()` seem to be redundant and can be replaced with `instanceof`.

Also, I'm confused by the line 

```
 $value > 2 ^ 32 - 1
```
where `2 ^ 32 - 1` is evaluated to `29` (because `^` is a bitwise XOR operator). Was it meant to be `2 ** 32 - 1`? If so, is it a sort of integer overflow detection or is there another cause (FTR, rybakit/msgpack converts overflowed integers to strings [by default](https://github.com/rybakit/msgpack.php#unpacking-options))?