### PR TITLE
fix: deep wrapping binary string in array/map tuple fields

### DIFF
--- a/php/Job/Space/Select.php
+++ b/php/Job/Space/Select.php
@@ -76,12 +76,12 @@ class Select extends Job
         }
 
         if (!json_encode($data)) {
-            foreach ($data as $i => $tuple) {
-                foreach ($tuple as $k => $v) {
+            foreach ($data as $i => &$tuple) {
+                array_walk_recursive($tuple, function (&$v) {
                     if (is_string($v) && !json_encode($v)) {
-                        $data[$i][$k] = '!!binary ' . base64_encode($v);
+                        $v = '!!binary ' . base64_encode($v);
                     }
-                }
+                });
             }
         }
 


### PR DESCRIPTION
``` lua
version: "3.7"

services:
  tarantool-admin:
    image: quay.io/basis-company/tarantool-admin:0.7.11
    ports: ["8001:80"]
    environment:
      TARANTOOL_CONNECTIONS: "tnt:3301"

  tnt:
    image: tarantool/tarantool:2.11.2-ubuntu20.04
    command: sh -c 'tarantool -e "$$COMMAND"'
    ports: ["3301:3301"]

    environment:
      COMMAND: | #lua
        box.cfg({ listen = 3301 })

        box.schema.user.grant("guest", "super", nil, nil, {})

        local space = box.schema.space.create("TEST", {
          format = {
            { name = "id", type = "unsigned" },
            { name = "any", type = "any" },
          },
        })

        space:create_index("PRIMARY", {
          parts = { { field = "id", type = "unsigned" } },
        })

        space:insert({ 1, "\b\xFF\x01" })
        space:insert({ 2, { "\b\xFF\x01" } })
        space:insert({ 3, { a = "\b\xFF\x01" } })
        space:insert({ 4, { a = { "\b\xFF\x01" } } })

```


in 0.7.11:
![image](https://github.com/basis-company/tarantool-admin/assets/43112758/42053c85-6ff5-47a9-a4cf-e0e146e7c69a)


in fix:
![image](https://github.com/basis-company/tarantool-admin/assets/43112758/9938abcd-0743-4d83-a76e-c0f58d85202c)

